### PR TITLE
Add basic ML pipeline for generating Dead-style audio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv/
+__pycache__/
+models/
+*.wav

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# Everlasting Dead
+
+This repository contains a minimal example of how you could train a
+machine learning model on a collection of Grateful Dead live
+recordings and then generate new audio in a similar style. The
+repository does not include any copyrighted audio files. You must
+provide your own dataset of Grateful Dead live recordings and place the
+files inside the `data/` directory (or adjust the path in the training
+script).
+
+**Disclaimer**: Training a high‑quality generative model on audio data
+is computationally expensive. The code here is intended as a starting
+point only. It uses a simple recurrent neural network and
+`torchaudio` for audio processing. Feel free to adapt the code to more
+advanced models.
+
+## Setup
+
+1. Install Python 3.10 or higher.
+2. Create a virtual environment and install dependencies:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+3. Place your Grateful Dead live recordings (e.g. FLAC or WAV files)
+   under the `data/` directory. You can obtain many of these legally
+   from [archive.org](https://archive.org/details/GratefulDead).
+
+## Training
+
+Run the training script with:
+
+```bash
+python src/train.py --data_dir data --epochs 10 --model_dir models
+```
+
+This will preprocess the audio into Mel spectrograms and train a simple
+sequence model. The trained weights will be saved in `models/`.
+
+## Generating Audio
+
+After training, you can generate a new audio clip with:
+
+```bash
+python src/generate.py --model_dir models --output_file generated.wav
+```
+
+The script loads the latest checkpoint in `models/` and produces a
+short audio sample saved to `generated.wav`.
+
+## Notes
+
+- The provided scripts are intentionally lightweight. For serious
+  results, consider more sophisticated architectures like WaveNet,
+  DiffWave, or fine‑tuned transformers.
+- Always respect copyright laws when downloading or distributing
+  recordings.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+torch
+torchaudio

--- a/src/generate.py
+++ b/src/generate.py
@@ -1,0 +1,60 @@
+import argparse
+import glob
+import os
+
+import torch
+import torchaudio
+from torch import nn
+
+
+def build_model(n_mels):
+    return nn.GRU(
+        input_size=n_mels, hidden_size=256, num_layers=2, batch_first=True
+    )
+
+
+def load_checkpoint(model_dir):
+    ckpts = sorted(glob.glob(os.path.join(model_dir, "model.pt")))
+    if not ckpts:
+        raise FileNotFoundError("No checkpoint found")
+    ckpt_path = ckpts[-1]
+    state = torch.load(ckpt_path, map_location="cpu")
+    model = build_model(n_mels=80)
+    model.load_state_dict(state)
+    model.eval()
+    return model
+
+
+def generate(model, length=16000, sample_rate=16000):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    hidden = None
+    n_mels = 80
+    output = torch.zeros(1, 1, n_mels).to(device)
+    mel_frames = []
+    for _ in range(length):
+        out, hidden = model(output, hidden)
+        output = out[:, -1:, :]
+        mel_frames.append(output.squeeze(0).squeeze(0).cpu())
+    mel = torch.stack(mel_frames).transpose(0, 1)
+    inv_mel = torchaudio.transforms.InverseMelScale(n_stft=201, n_mels=n_mels)
+    griffin_lim = torchaudio.transforms.GriffinLim(n_fft=400, hop_length=160)
+    spec = inv_mel(mel)
+    waveform = griffin_lim(spec)
+    return waveform
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_dir", default="models")
+    parser.add_argument("--output_file", default="generated.wav")
+    args = parser.parse_args()
+
+    model = load_checkpoint(args.model_dir)
+    waveform = generate(model)
+    torchaudio.save(args.output_file, waveform, 16000)
+    print(f"Saved audio to {args.output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,103 @@
+import argparse
+import glob
+import os
+
+import torch
+import torchaudio
+from torch import nn
+from torch.utils.data import Dataset, DataLoader
+
+
+class AudioDataset(Dataset):
+    """Loads audio files and converts them to mel spectrogram tensors."""
+
+    def __init__(
+        self, data_dir, sample_rate=16000, n_fft=400, hop_length=160, n_mels=80
+    ):
+        self.files = sorted(
+            [
+                f
+                for f in glob.glob(os.path.join(data_dir, "*"))
+                if f.lower().endswith((".wav", ".flac"))
+            ]
+        )
+        self.mel = torchaudio.transforms.MelSpectrogram(
+            sample_rate=sample_rate,
+            n_fft=n_fft,
+            hop_length=hop_length,
+            n_mels=n_mels,
+        )
+        self.sample_rate = sample_rate
+
+    def __len__(self):
+        return len(self.files)
+
+    def __getitem__(self, idx):
+        waveform, sr = torchaudio.load(self.files[idx])
+        if sr != self.sample_rate:
+            waveform = torchaudio.functional.resample(
+                waveform, sr, self.sample_rate
+            )
+        mel_spec = (
+            self.mel(waveform).squeeze(0).transpose(0, 1)
+        )  # (time, n_mels)
+        return mel_spec
+
+
+def collate_fn(batch):
+    # Pad sequences to the same length
+    lengths = [b.size(0) for b in batch]
+    max_len = max(lengths)
+    n_mels = batch[0].size(1)
+    padded = torch.zeros(len(batch), max_len, n_mels)
+    for i, b in enumerate(batch):
+        padded[i, : b.size(0)] = b
+    return padded, torch.tensor(lengths)
+
+
+def build_model(n_mels):
+    return nn.GRU(
+        input_size=n_mels, hidden_size=256, num_layers=2, batch_first=True
+    )
+
+
+def train(model, dataloader, epochs, device):
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    criterion = nn.MSELoss()
+    model.train()
+    for epoch in range(epochs):
+        for batch, lengths in dataloader:
+            batch = batch.to(device)
+            output, _ = model(batch)
+            loss = criterion(output, batch)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+        print(f"Epoch {epoch+1}/{epochs} - Loss: {loss.item():.4f}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data_dir", required=True)
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--model_dir", default="models")
+    args = parser.parse_args()
+
+    os.makedirs(args.model_dir, exist_ok=True)
+    dataset = AudioDataset(args.data_dir)
+    dataloader = DataLoader(
+        dataset, batch_size=4, shuffle=True, collate_fn=collate_fn
+    )
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = build_model(n_mels=80).to(device)
+
+    train(model, dataloader, args.epochs, device)
+
+    ckpt_path = os.path.join(args.model_dir, "model.pt")
+    torch.save(model.state_dict(), ckpt_path)
+    print(f"Saved model to {ckpt_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- set up repo with README and requirements
- add basic GRU training script for audio spectrograms
- add generation script to produce waveforms from a trained model
- ignore models and output files

## Testing
- `black src/train.py --line-length 79`
- `black src/generate.py --line-length 79`


------
https://chatgpt.com/codex/tasks/task_b_685cbf50562c8333aee64e050d0a58e3